### PR TITLE
Email fix

### DIFF
--- a/opt/samples/blanks-test.json
+++ b/opt/samples/blanks-test.json
@@ -1,0 +1,149 @@
+{
+  "slug" : "july-2016-update-748a5",
+  "sections" : [ "update", "highlights", "custom-89de", "growth", "finances", "challenges", "team", "help" ],
+  "logo" : "https://open-company-assets.s3.amazonaws.com/green-labs.png",
+  "challenges" : {
+    "description" : "Challenges facing the company",
+    "updated-at" : "2016-07-28T17:55:36.642Z",
+    "image-url" : "https://cdn.filestackcontent.com/b80F13kRte5FLyGIPFFN",
+    "headline" : "Recruiting; maintaining growth are focus areas",
+    "image-width" : 462,
+    "image-height" : 348,
+    "title" : "Key Challenges",
+    "author" : {
+      "image" : "https://avatars.slack-edge.com/2016-01-04/17691305283_beac02319067680e6936_192.jpg",
+      "name" : "Stuart Levinson",
+      "user-id" : "78901"
+    },
+    "body" : "<p>We've done a relatively good job onboarding 7 new hires so far this year; but just as many roles haven't been filled yet. Among them is the Chief Designer, and that's affecting our ability to iterate quickly. We're turning to recruiters to help us with at least that position.</p><p>Word of mouth has helped us to grow, but we have to find ways to build virality into the product, as well. In the meantime, we're testing a new campaign to drive growth.</p>",
+    "created-at" : "2016-07-28T17:55:36.642Z"
+  },
+  "name" : "GreenLabs",
+  "highlights" : null,
+  "update" : {
+    "description" : "Company update",
+    "updated-at" : "2016-07-28T18:25:03.085Z",
+    "image-url" : null,
+    "headline" : "Passing $1M in ARR ↗ 💸",
+    "image-width" : 0,
+    "image-height" : 0,
+    "title" : null,
+    "author" : {
+      "image" : "https://avatars.slack-edge.com/2016-01-04/17691305283_beac02319067680e6936_192.jpg",
+      "name" : "Stuart Levinson",
+      "user-id" : "78901"
+    },
+    "body" : "<p>We hit our targets and hit a new sales record, adding $125K in ARR so far this month!</p>",
+    "created-at" : "2016-07-28T18:25:03.085Z"
+  },
+  "title" : "July 2016 Update",
+  "author" : {
+    "image" : "https://secure.gravatar.com/avatar/866a6350e399e67e749c6f2aef0b96c0.jpg?s=192&d=https%3A%2F%2Fa.slack-edge.com%2F7fa9%2Fimg%2Favatars%2Fava_0020-192.png",
+    "name" : "Sean Johnson",
+    "user-id" : "slack:U06SBTXJR"
+  },
+  "currency" : "USD",
+  "team" : {
+    "description" : "Team and hiring update",
+    "updated-at" : "2016-07-28T18:02:07.397Z",
+    "image-url" : null,
+    "headline" : "Welcome!",
+    "image-width" : 0,
+    "image-height" : 0,
+    "title" : "Team and Hiring",
+    "author" : {
+      "image" : "https://avatars.slack-edge.com/2016-01-04/17691305283_beac02319067680e6936_192.jpg",
+      "name" : "Stuart Levinson",
+      "user-id" : "78901"
+    },
+    "body" : null,
+    "created-at" : "2016-07-28T18:02:07.397Z"
+  },
+  "finances" : {
+    "description" : "Cash on hand, burn and runway",
+    "updated-at" : "2016-08-24T16:20:11.411Z",
+    "image-url" : null,
+    "headline" : "Revenue rising, expenses steady&nbsp;⚖",
+    "image-width" : 0,
+    "section" : "finances",
+    "body-placeholder" : "What would you like to say about company finances?",
+    "image-height" : 0,
+    "title" : "Finances",
+    "author" : {
+      "image" : "https://avatars.slack-edge.com/2016-01-04/17691305283_beac02319067680e6936_192.jpg",
+      "name" : "Stuart Levinson",
+      "user-id" : "slack:U06SQLDFT"
+    },
+    "body" : "<p>Though monthly expenses have been kept in check, we expect to ramp up marketing expenses in the fall to pursue a higher rate of growth.</p><p>Our cash runway is growing because of the revenue, but we are still planning a capital raise in early 2017 so we can grow the team more quickly.</p>",
+    "created-at" : "2016-08-24T16:19:57.515Z",
+    "data" : null
+  },
+  "custom-89de" : {
+    "description" : null,
+    "updated-at" : "2016-07-28T18:05:09.308Z",
+    "image-url" : null,
+    "headline" : "July 2016",
+    "image-width" : 0,
+    "image-height" : 0,
+    "title" : "KPI's",
+    "author" : {
+      "image" : "https://avatars.slack-edge.com/2016-01-04/17691305283_beac02319067680e6936_192.jpg",
+      "name" : "Stuart Levinson",
+      "user-id" : "78901"
+    },
+    "body" : "<ul><li>Total Revenue $83K<br></li><li>MRR: $79K</li><li>MRR Bookings $12.5K (goal $12K)</li><li>Revenue Churn: 4.2% (goal 3%)</li></ul>",
+    "created-at" : "2016-07-28T18:05:09.308Z"
+  },
+  "help" : {
+    "description" : "Ask your company stakeholders for help and ideas",
+    "updated-at" : "2016-07-28T18:07:42.845Z",
+    "image-url" : null,
+    "headline" : null,
+    "image-width" : 0,
+    "image-height" : 0,
+    "title" : "How You Can Help",
+    "author" : {
+      "image" : "https://avatars.slack-edge.com/2016-01-04/17691305283_beac02319067680e6936_192.jpg",
+      "name" : "Stuart Levinson",
+      "user-id" : "78901"
+    },
+    "body" : "<p>Please introduce us to designers and anyone that might eventually lead us to a new Chief Designer. This is holding us back, and we need everyone's help!</p><p>We've outgrown our SF office. If you know of a sublease or reasonable deal for 5k square ft please let Rebekah know.</p><p><br></p>",
+    "created-at" : "2016-07-28T18:07:42.845Z"
+  },
+  "growth" : {
+    "description" : "Growth metrics and key performance indicators",
+    "updated-at" : "2016-08-24T16:44:10.331Z",
+    "image-url" : null,
+    "headline" : "Automated Lab Work Tops 20%",
+    "image-width" : 0,
+    "section" : "growth",
+    "body-placeholder" : "Provide context about recent growth. Why are these metrics important? How are they performing against targets? What is impacting them?",
+    "image-height" : 0,
+    "title" : "Growth",
+    "author" : {
+      "image" : "https://avatars.slack-edge.com/2016-01-04/17691305283_beac02319067680e6936_192.jpg",
+      "name" : "Stuart Levinson",
+      "user-id" : "slack:U06SQLDFT"
+    },
+    "body" : "<p>The past two years have seen the greatest increase in lab work assigned to robots, but this is the first time the 20% threshold has been breached.</p><p>Automation is expected to handle up to 80% within five years.</p>",
+    "created-at" : "2016-08-24T16:38:41.576Z",
+    "metrics" : null,
+    "data" : null
+  },
+  "created-at" : "2016-08-24T23:14:20.765Z",
+  "links" : [ {
+    "rel" : "self",
+    "method" : "GET",
+    "href" : "/companies/green-labs/updates/july-2016-update-748a5",
+    "type" : "application/vnd.open-company.stakeholder-update.v1+json"
+  }, {
+    "rel" : "company",
+    "method" : "GET",
+    "href" : "/companies/green-labs",
+    "type" : "application/vnd.open-company.company.v1+json"
+  }, {
+    "rel" : "delete",
+    "method" : "DELETE",
+    "href" : "/companies/green-labs/updates/july-2016-update-748a5"
+  } ]
+}

--- a/src/oc/email/content.clj
+++ b/src/oc/email/content.clj
@@ -67,9 +67,9 @@
       (when image-url (topic-image image-url))
        [:tr
         [:th {:class "small-12 large-12 columns first last"}
-          (when (:title topic)
+          (when-not (s/blank? (:title topic))
             (spacer 24))
-          (when (:title topic)
+          (when-not (s/blank? (:title topic))
             [:p {:class "topic-title"} (s/upper-case (:title topic))])
           (spacer 1)
           [:p {:class "topic-headline"} (:headline topic)]
@@ -155,9 +155,9 @@
     [:table {:class "row topic"}
       [:tr
         [:th {:class "small-12 large-12 columns first last"}
-          (when (:title topic)
+          (when-not (s/blank? (:title topic))
             (spacer 24))
-          (when (:title topic)
+          (when-not (s/blank? (:title topic))
             [:p {:class "topic-title"} (s/upper-case (:title topic))])
           (spacer 1)
           [:p {:class "topic-headline"} (:headline topic)]

--- a/src/oc/email/content.clj
+++ b/src/oc/email/content.clj
@@ -67,8 +67,10 @@
       (when image-url (topic-image image-url))
        [:tr
         [:th {:class "small-12 large-12 columns first last"}
-          (spacer 24)
-          [:p {:class "topic-title"} (s/upper-case (:title topic))]
+          (when (:title topic)
+            (spacer 24))
+          (when (:title topic)
+            [:p {:class "topic-title"} (s/upper-case (:title topic))])
           (spacer 1)
           [:p {:class "topic-headline"} (:headline topic)]
           (when body? (spacer 2))
@@ -153,8 +155,10 @@
     [:table {:class "row topic"}
       [:tr
         [:th {:class "small-12 large-12 columns first last"}
-          (spacer 24)
-          [:p {:class "topic-title"} (s/upper-case (:title topic))]
+          (when (:title topic)
+            (spacer 24))
+          (when (:title topic)
+            [:p {:class "topic-title"} (s/upper-case (:title topic))])
           (spacer 1)
           [:p {:class "topic-headline"} (:headline topic)]
           (when body? (spacer 2))

--- a/src/oc/email/content.clj
+++ b/src/oc/email/content.clj
@@ -73,7 +73,7 @@
       [:table {:class "row topic"}
         (when image-url?
           (topic-image image-url))
-        (when (or title? headline? body?))
+        (when (or title? headline? body?)
           [:tr
             [:th {:class "small-12 large-12 columns first last"}
               (spacer 24)
@@ -85,7 +85,7 @@
               (when body? (spacer 2))
               (when body? body)
               (spacer 20)]
-            [:th {:class "expander"}]]])))
+            [:th {:class "expander"}]])])))
 
 (defn- metric
   ([label value] (metric label value :nuetral))

--- a/src/oc/email/content.clj
+++ b/src/oc/email/content.clj
@@ -61,22 +61,31 @@
       [:img {:src image-url}]]])
 
 (defn- content-topic [snapshot topic-name topic topic-url]
-  (let [body? (not (s/blank? (:body topic)))
-        image-url (:image-url topic)]
-    [:table {:class "row topic"}
-      (when image-url (topic-image image-url))
-       [:tr
-        [:th {:class "small-12 large-12 columns first last"}
-          (when-not (s/blank? (:title topic))
-            (spacer 24))
-          (when-not (s/blank? (:title topic))
-            [:p {:class "topic-title"} (s/upper-case (:title topic))])
-          (spacer 1)
-          [:p {:class "topic-headline"} (:headline topic)]
-          (when body? (spacer 2))
-          (when body? (:body topic))
-          (spacer 20)]
-        [:th {:class "expander"}]]]))
+  (let [title (:title topic)
+        title? (not (s/blank? title))
+        headline (:headline topic)
+        headline? (not (s/blank? headline))
+        body (:body topic)
+        body? (not (s/blank? body))
+        image-url (:image-url topic)
+        image-url? (not (s/blank? image-url))]
+    (when (or image-url? title? headline? body?)
+      [:table {:class "row topic"}
+        (when image-url?
+          (topic-image image-url))
+        (when (or title? headline? body?))
+          [:tr
+            [:th {:class "small-12 large-12 columns first last"}
+              (spacer 24)
+              (when title?
+                [:p {:class "topic-title"} (s/upper-case title)])
+              (when title? (spacer 1))
+              (when headline?
+                [:p {:class "topic-headline"} headline])
+              (when body? (spacer 2))
+              (when body? body)
+              (spacer 20)]
+            [:th {:class "expander"}]]])))
 
 (defn- metric
   ([label value] (metric label value :nuetral))
@@ -318,5 +327,8 @@
 
   (def snapshot (json/decode (slurp "./opt/samples/growth-options.json")))
   (spit "./hiccup.html" (content/html (-> snapshot (assoc :note "") (assoc :company-slug "growth-options"))))
+
+  (def snapshot (json/decode (slurp "./opt/samples/blanks-test.json")))
+  (spit "./hiccup.html" (content/html (-> snapshot (assoc :note "") (assoc :company-slug "blanks-test"))))
 
   )

--- a/src/oc/lib/utils.clj
+++ b/src/oc/lib/utils.clj
@@ -85,7 +85,7 @@
   ""
   [value]
   {:pre [(string? value)]
-   :post [(string? value)]}
+   :post [(string? %)]}
   (if-not (or (and (s/ends-with? value "0") (.contains value "."))
               (s/ends-with? value "."))
     value


### PR DESCRIPTION
card: https://trello.com/c/Bscom3aD

This PR makes the email service more resilient to handle nulls in update data:
- whole topic
- title
- headline
- body
- finance data
- growth metadata
- growth data

To test:

There is a new sample data file in email called `blanks-test.json` that contains all of the above.

You can test rendering it at the REPL with:

```
(require '[oc.email.content :as content] :reload)
(def snapshot (json/decode (slurp "./opt/samples/blanks-test.json")))
(spit "./hiccup.html" (content/html (-> snapshot (assoc :note "") (assoc :company-slug "blanks-test"))))
```

View the resulting `hiccup.html` file in your browser.

NB: This is already deployed to staging and beta.
