### PR TITLE
Size

### DIFF
--- a/resources/css/oc-snapshot.css
+++ b/resources/css/oc-snapshot.css
@@ -143,7 +143,7 @@ img.sparkline, img.sparkbar {
 /* === Footer === */
 
 table.footer {
-  background: #f9f9f9;
+  background: transparent;
   display: table;
   width: 100%;
 }

--- a/resources/snapshot-link.html
+++ b/resources/snapshot-link.html
@@ -1,0 +1,162 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+  <head>
+    <!-- The character set should be utf-8 -->
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+    <!-- Enables media queries -->
+    <meta name="viewport" content="width=device-width"/>
+    <title></title>
+    <!-- Link to the email's CSS, which will be inlined into the email -->
+    <link rel="stylesheet" href="css/foundation.css"/>
+    <link rel="stylesheet" href="css/oc-invite.css"/>
+    <!-- Link to web fonts -->
+    <link href='http://fonts.googleapis.com/css?family=Domine' rel='stylesheet' type='text/css'/>
+    <link href='http://fonts.googleapis.com/css?family=Open+Sans' rel='stylesheet' type='text/css'/>
+  </head>
+
+  <body>
+
+      <!-- Wrapper for the body of the email -->
+      <table class="body">
+        <tr>
+          <!-- The class, align, and <center> tag center the container -->
+          <td class="float-center" align="center" valign="top">
+            <center>
+
+              <table class="container">
+                <tr>
+                  <td>
+              
+                    <!-- The content of your email goes here. -->
+                
+                    <!-- spacer -->
+                    <table class="row">
+                      <tr>
+                        <th class="small-12 large-12 first last columns">
+                          <table>
+                            <tr>
+                              <th>
+                                <table class="spacer">
+                                  <tr>
+                                    <td height="25px" style="font-size:25px;line-height:25px;">&#xA0;</td>
+                                  </tr>
+                                </table>
+                              </th>
+                              <th class="expander"></th>
+                            </tr>
+                          </table>
+                        </th>
+                      </tr>
+                    </table>
+
+                    <table class="row">
+                      <tr>
+                        <th class="small-12 large-12 first last columns">
+                          <table>
+                            <tr>
+                              <th>
+                                <center data-parsed="">
+                                  <img class="float-center logo" align="center" style="background-color: #ffffff;
+                            border: solid 1px rgba(78, 90, 107, 0.2);" height="50px" width="50px" src="https://www.apple.com/ac/structured-data/images/knowledge_graph_logo.png" alt="Apple logo"/>
+                                </center>
+                              </th>
+                            </tr>
+                          </table>
+                        </th>
+                      </tr>
+                    </table>
+
+                    <!-- spacer -->
+                    <table class="row">
+                      <tr>
+                        <th class="small-12 large-12 first last columns">
+                          <table>
+                            <tr>
+                              <th>
+                                <table class="spacer">
+                                  <tr>
+                                    <td height="35px" style="font-size:35px;line-height:35px;">&#xA0;</td>
+                                  </tr>
+                                </table>
+                              </th>
+                              <th class="expander"></th>
+                            </tr>
+                          </table>
+                        </th>
+                      </tr>
+                    </table>
+
+                    <table class="row">
+                      <tr>
+                        <th class="small-2 large-2 first columns">
+                        </th>
+                        <th class="small-8 large-8 columns">
+                          <p class="text-center">Check out the latest from Apple!</p>
+                        </th>
+                        <th class="small-2 large-2 last columns">
+                        </th>
+                        <th class="expander"></th>
+                      </tr>
+                    </table>
+
+                    <!-- spacer -->
+                    <table class="row">
+                      <tr>
+                        <th class="small-12 large-12 first last columns">
+                          <table>
+                            <tr>
+                              <th>
+                                <table class="spacer">
+                                  <tr>
+                                    <td height="25px" style="font-size:25px;line-height:25px;">&#xA0;</td>
+                                  </tr>
+                                </table>
+                              </th>
+                              <th class="expander"></th>
+                            </tr>
+                          </table>
+                        </th>
+                      </tr>
+                    </table>
+                  
+
+                  <table class="row">
+                    <tbody>
+                      <tr>
+                        <th class="small-12 large-12 columns first last">
+                          <table>
+                            <tr>
+                              <th>
+                                <center data-parsed="">
+                                  <table class="button oc radius large float-center">
+                                    <tr>
+                                      <td>
+                                        <table>
+                                          <tr>
+                                            <td><a href="#">READ THE UPDATE ➞</a></td>
+                                          </tr>
+                                        </table>
+                                      </td>
+                                    </tr>
+                                  </table>
+                                </center>
+                              </th>
+                              <th class="expander"></th>
+                            </tr>
+                          </table>
+                        </th>
+                      </tr>
+                    </tbody>
+                  </table>
+                  
+                </td>
+              </tr>
+            </table>
+
+          </center>
+        </td>
+      </tr>
+    </table>
+
+  </body>
+</html>

--- a/src/oc/email/config.clj
+++ b/src/oc/email/config.clj
@@ -7,6 +7,8 @@
   [val]
   (boolean (Boolean/valueOf val)))
 
+;; ----- System -----
+
 (defonce intro? (bool (or (env :intro ) false)))
 
 ;; ----- Logging -----

--- a/src/oc/email/mailer.clj
+++ b/src/oc/email/mailer.clj
@@ -48,7 +48,12 @@
               to))))
 
 (defn- inline-css [html-file inline-file]
-  (shell/sh "juice" "--web-resources-images" "false" html-file inline-file))
+  (shell/sh "juice" 
+            "--web-resources-images" "false"
+            "--remove-style-tags" "true"
+            "--preserve-media-queries" "false"
+            "--preserve-font-faces" "false"
+            html-file inline-file))
 
 (defn send-snapshot
   "Create an HTML snapshot and email it to the specified recipients."
@@ -76,7 +81,7 @@
           ;; Render an alternative, smaller email
           (spit html-file (content/snapshot-link-html full-snapshot)) ; create the email in a tmp file
           (inline-css html-file inline-file))) ; inline the CSS
-      ;; Email the recipients
+      ; Email the recipients
       (email-snapshots msg (slurp inline-file))
       (finally
         ; remove the tmp files

--- a/src/oc/email/mailer.clj
+++ b/src/oc/email/mailer.clj
@@ -71,12 +71,12 @@
         (when (>= file-size size-limit)
           ;; Send a Sentry notification
           (when c/dsn ; Sentry is configured
-            (sentry/capture c/dsn {:message (str "Rendered update email is over size limit at "
-                                                 (int (Math/ceil (/ file-size 1000)))
-                                                 "KB")
+            (sentry/capture c/dsn {:message "Rendered update email is over size limit"
                                    :extra {
                                       :company-slug (:company-slug snapshot)
                                       :update-slug (:slug snapshot)
+                                      :human-size (str (int (Math/ceil (/ file-size 1000))) "KB")
+                                      :size file-size
                                       :topic-count (count (:sections snapshot))}}))
           ;; Render an alternative, smaller email
           (spit html-file (content/snapshot-link-html full-snapshot)) ; create the email in a tmp file


### PR DESCRIPTION
https://trello.com/c/DDdcJc3k

This PR deals w/ size limitations of share update emails in GMail clients.

* Reduce likelihood size is > 100KB by adjusting CSS inlining settings
* Check if rendered email size is > 100KB, if it is, send us a Sentry
* If rendered email size is > 100KB, don't send the rendered email, instead send a simpler link email

To test:

* Send some various share emails, check in various email clients. Still look right?
* Locally, change line 12 of `mailer.clj` to be 1K rather than 100K and send some emails, you get a link email instead? OR on staging use Buffer w/ every topic selected. Do you get the slim email? Try it w/ and w/o a title.
* Set your `SENTRY_DSN` env. var to a valid Sentry project, OR on staging check Sentry, repeat the step above, do you get a Sentry saying it happened w/ some details on the size, company, update slug and # of topics?
* Merge
* Deploy to beta
* [Sing and dance the Cuban Pete](https://www.youtube.com/watch?v=6-hk_7Ln-MM)
