### PR TITLE
Update for sharing posts rather than stories by email.

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -51,7 +51,7 @@
       }
       :plugins [
         ;; Linter https://github.com/jonase/eastwood
-        [jonase/eastwood "0.2.5"]
+        [jonase/eastwood "0.2.6-beta2"]
         ;; Static code search for non-idiomatic code https://github.com/jonase/kibit
         [lein-kibit "0.1.6-beta2" :exclusions [org.clojure/clojure]]
       ]
@@ -74,13 +74,13 @@
       :plugins [
         ;; Check for code smells https://github.com/dakrone/lein-bikeshed
         ;; NB: org.clojure/tools.cli is pulled in by lein-kibit
-        [lein-bikeshed "0.4.1" :exclusions [org.clojure/tools.cli]] 
+        [lein-bikeshed "0.5.0" :exclusions [org.clojure/tools.cli]] 
         ;; Runs bikeshed, kibit and eastwood https://github.com/itang/lein-checkall
         [lein-checkall "0.1.1"]
         ;; pretty-print the lein project map https://github.com/technomancy/leiningen/tree/master/lein-pprint
         [lein-pprint "1.1.2"]
         ;; Check for outdated dependencies https://github.com/xsc/lein-ancient
-        [lein-ancient "0.6.12"]
+        [lein-ancient "0.6.14"]
         ;; Catch spelling mistakes in docs and docstrings https://github.com/cldwalker/lein-spell
         [lein-spell "0.1.0"]
         ;; Dead code finder https://github.com/venantius/yagni

--- a/project.clj
+++ b/project.clj
@@ -14,17 +14,17 @@
   ;; All profile dependencies
   :dependencies [
     ;; Lisp on the JVM http://clojure.org/documentation
-    [org.clojure/clojure "1.9.0-beta1"]
+    [org.clojure/clojure "1.9.0-beta2"]
     ;; HTML rendering https://github.com/weavejester/hiccup
     [hiccup "2.0.0-alpha1"]
     ;; Async programming tools https://github.com/ztellman/manifold
-    [manifold "0.1.7-alpha5"]
+    [manifold "0.1.7-alpha6"]
     ;; Namespace management https://github.com/clojure/tools.namespace
     ;; NB: org.clojure/tools.reader is pulled in by oc.lib
     [org.clojure/tools.namespace "0.3.0-alpha4" :exclusions [org.clojure/tools.reader]] 
 
     ;; Library for OC projects https://github.com/open-company/open-company-lib
-    [open-company/lib "0.14.5"]
+    [open-company/lib "0.14.7"]
     ;; In addition to common functions, brings in the following common dependencies used by this project:
     ;; Component - Component Lifecycle https://github.com/stuartsierra/component
     ;; Schema - Data validation https://github.com/Prismatic/schema
@@ -51,7 +51,7 @@
       }
       :plugins [
         ;; Linter https://github.com/jonase/eastwood
-        [jonase/eastwood "0.2.4"]
+        [jonase/eastwood "0.2.5"]
         ;; Static code search for non-idiomatic code https://github.com/jonase/kibit
         [lein-kibit "0.1.6-beta2" :exclusions [org.clojure/clojure]]
       ]

--- a/src/oc/email/app.clj
+++ b/src/oc/email/app.clj
@@ -18,7 +18,7 @@
       "reset" (mailer/send-token :reset msg-body)
       "verify" (mailer/send-token :verify msg-body)
       "invite" (mailer/send-invite msg-body)
-      "story" (mailer/send-story msg-body)
+      "share-entry" (mailer/send-entry msg-body)
       (timbre/error "Unrecognized message type" msg-type)))
   (sqs/ack done-channel msg))
 

--- a/src/oc/email/content.clj
+++ b/src/oc/email/content.clj
@@ -231,26 +231,6 @@
 (defn share-link-html [entry]
   (html entry :share-link))
 
-; (defn- share-link-content [entry]
-;   (let [org-name (:org-name entry)
-;         org-name? (not (s/blank? org-name))
-;         headline (:headline entry)
-;         headline? (not (s/blank? headline))
-;         link-title (if headline? headline (str org-name " Post"))
-;         org-slug (:org-slug entry)
-;         secure-uuid (:secure-uuid entry)
-;         origin-url config/web-url
-;         update-url (s/join "/" [origin-url org-slug "post" secure-uuid])]
-;     [:table {:class "note"}
-;       [:tr
-;         [:td 
-;           [:table {:class "row note"}
-;             [:tr
-;               [:th {:class "small-12 large-12 first last columns note"}
-;                 "Check out the latest"
-;                 (when org-name? (str " from " org-name))
-;                 ": " [:a {:href update-url} link-title]]]]]]]))
-
 (defn share-link-text [entry]
   (let [note (:note entry)
         note? (not (s/blank? note))

--- a/src/oc/email/content.clj
+++ b/src/oc/email/content.clj
@@ -189,16 +189,16 @@
       (carrot-logo)
       (paragraph tagline)]))
 
-(defn- story-link-content [story]
-  (let [org-name (:org-name story)
+(defn- share-link-content [entry]
+  (let [org-name (:org-name entry)
         org-name? (not (s/blank? org-name))
-        title (:title story)
-        title? (not (s/blank? title))
-        link-title (if title? title (str org-name " Update"))
-        org-slug (:org-slug story)
-        secure-uuid (:secure-uuid story)
+        headline (:headline entry)
+        headline? (not (s/blank? headline))
+        link-title (if headline? headline (str org-name " Post"))
+        org-slug (:org-slug entry)
+        secure-uuid (:secure-uuid entry)
         origin-url config/web-url
-        update-url (s/join "/" [origin-url org-slug "story" secure-uuid])]
+        update-url (s/join "/" [origin-url org-slug "post" secure-uuid])]
     [:table {:class "note"}
       [:tr
         [:td 
@@ -237,16 +237,16 @@
 
 (defn- body [data]
   (let [type (:type data)
-        trail-space? (not= type :update-link)]
+        trail-space? (not= type :share-link)]
     [:body
       [:table {:class "body"}
         [:tr
           [:td {:class "float-center", :align "center", :valign "top"}
             (when-not (s/blank? (:note data)) (note data trail-space?))
-            (when (and (s/blank? (:note data)) (= type :update-link)) (spacer 15 "note"))
+            (when (and (s/blank? (:note data)) (= type :share-link)) (spacer 15 "note"))
             (when (= type :update) (spacer 55 "blank"))
-            (if (= type :update-link)
-              (story-link-content data)     
+            (if (= type :share-link)
+              (share-link-content data)     
               [:center
                 [:table {:class "container"}
                   [:tr
@@ -282,8 +282,8 @@
         org (if (s/blank? org-name) "" (str org-name " on "))]
     (str prefix " to join " org "Carrot.")))
 
-(defn story-link-html [update]
-  (html update :update-link))
+(defn share-link-html [update]
+  (html update :share-link))
 
 (defn update-html [update]
   (html update :update))

--- a/src/oc/email/mailer.clj
+++ b/src/oc/email/mailer.clj
@@ -40,7 +40,7 @@
                         :source (str org-name " <" org-slug "@" c/email-from-domain ">")
                         :reply-to (if (s/blank? reply-to) default-reply-to reply-to)
                         :subject subject}
-                  {:html body})
+                  {:text body}) ; TEMP as text only
             to)))
 
 (defn- inline-css [html-file inline-file]
@@ -58,10 +58,13 @@
         html-file (str uuid-fragment ".html")
         inline-file (str uuid-fragment ".inline.html")]
     (try
-      (spit html-file (content/share-link-html entry)) ; create the email in a tmp file
-      (inline-css html-file inline-file) ; inline the CSS
+      ;; COMMENTED OUT HTML EMAIL
+      ;;(spit html-file (content/share-link-html entry)) ; create the email in a tmp file
+      ;;(inline-css html-file inline-file) ; inline the CSS
       ;; Email the recipients
-      (email-entry entry (slurp inline-file))
+      ;;(email-entry entry (slurp inline-file))
+      ;; TEXT EMAIL
+      (email-entry entry (content/share-link-text entry))
       (finally
         ;; remove the tmp files
         (io/delete-file html-file true)

--- a/src/oc/email/mailer.clj
+++ b/src/oc/email/mailer.clj
@@ -33,7 +33,7 @@
       :message {:subject subject
                 :body html-body})))
 
-(defn- email-story
+(defn- email-entry
   "Send emails to all to recipients in parallel."
   [{:keys [to reply-to subject org-slug org-name]} body]
   (doall (pmap #(email {:to %
@@ -51,17 +51,17 @@
             "--preserve-font-faces" "false"
             html-file inline-file))
 
-(defn send-story
-  "Create an HTML story share and email it to the specified recipients."
-  [story]
+(defn send-entry
+  "Create an HTML email for the specified recipients."
+  [entry]
   (let [uuid-fragment (subs (str (java.util.UUID/randomUUID)) 0 4)
         html-file (str uuid-fragment ".html")
         inline-file (str uuid-fragment ".inline.html")]
     (try
-      (spit html-file (content/story-link-html story)) ; create the email in a tmp file
+      (spit html-file (content/share-link-html entry)) ; create the email in a tmp file
       (inline-css html-file inline-file) ; inline the CSS
       ;; Email the recipients
-      (email-story story (slurp inline-file))
+      (email-entry entry (slurp inline-file))
       (finally
         ;; remove the tmp files
         (io/delete-file html-file true)


### PR DESCRIPTION
Supports:

https://trello.com/c/4GSI3SB9
https://trello.com/c/3UzUesTW

Supports:

https://github.com/open-company/open-company-storage/pull/91

This PR updates the email service for sharing links to entries rather than links to stories. It also (temporarily pending a new design from Ryan) sends pure plain text shares rather than HTML shares as we had some issues with GMail flagging our HTML share content as spam.

Mainly review the code.

As for testing, it's been in use for some time on staging and beta, but you can share an entry in the UI and make sure you get a text email in response to the email addresses specified.
