### PR TITLE
If not a slack user, send email about the private board invite.

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -24,7 +24,7 @@
     [org.clojure/tools.namespace "0.3.0-alpha4" :exclusions [org.clojure/tools.reader]] 
 
     ;; Library for OC projects https://github.com/open-company/open-company-lib
-    [open-company/lib "0.14.15"]
+    [open-company/lib "0.16.2"]
     ;; In addition to common functions, brings in the following common dependencies used by this project:
     ;; Component - Component Lifecycle https://github.com/stuartsierra/component
     ;; Schema - Data validation https://github.com/Prismatic/schema
@@ -35,8 +35,6 @@
     ;; clj-time - Date and time lib https://github.com/clj-time/clj-time
     ;; Environ - Get environment settings from different sources https://github.com/weavejester/environ
   ]
-
-  :repositories [["jfreechart" "https://central.maven.org/maven2/"]]
 
   ;; All profile plugins
   :plugins [
@@ -75,7 +73,7 @@
       :plugins [
         ;; Check for code smells https://github.com/dakrone/lein-bikeshed
         ;; NB: org.clojure/tools.cli is pulled in by lein-kibit
-        [lein-bikeshed "0.5.0" :exclusions [org.clojure/tools.cli]] 
+        [lein-bikeshed "0.5.1" :exclusions [org.clojure/tools.cli]] 
         ;; Runs bikeshed, kibit and eastwood https://github.com/itang/lein-checkall
         [lein-checkall "0.1.1"]
         ;; pretty-print the lein project map https://github.com/technomancy/leiningen/tree/master/lein-pprint

--- a/src/oc/email/app.clj
+++ b/src/oc/email/app.clj
@@ -24,7 +24,7 @@
         msg-type (or (when (:Message msg-body) :sns) (:type msg-body))
         error (if (:test-error msg-body) (/ 1 0) false)] ; test Sentry error reporting
     (timbre/info "Received message from SQS.")
-    (timbre/tracef "\nMessage from SQS: %s\n" msg-body)
+    (timbre/debug "\nMessage (" msg-type ") from SQS:" msg-body "\n")
     (case (keyword msg-type)
       :reset (mailer/send-token :reset msg-body)
       :verify (mailer/send-token :verify msg-body)

--- a/src/oc/email/app.clj
+++ b/src/oc/email/app.clj
@@ -3,14 +3,25 @@
   (:require [com.stuartsierra.component :as component]
             [manifold.stream :as stream]
             [taoensso.timbre :as timbre]
+            [cheshire.core :as json]
             [oc.email.config :as c]
             [oc.lib.sentry-appender :as sentry]
             [oc.lib.sqs :as sqs]
             [oc.email.mailer :as mailer]))
 
+(defn- read-message-body
+  "
+  Try to parse as json, otherwise use read-string.
+  "
+  [msg]
+  (try
+    (json/parse-string msg true)
+    (catch Exception e
+      (read-string msg))))
+
 (defn sqs-handler [msg done-channel]
-  (let [msg-body (read-string (:body msg))
-        msg-type (:type msg-body)
+  (let [msg-body (read-message-body (:body msg))
+        msg-type (or (when (:Message msg-body) :sns) (:type msg-body))
         error (if (:test-error msg-body) (/ 1 0) false)] ; test Sentry error reporting
     (timbre/info "Received message from SQS.")
     (timbre/tracef "\nMessage from SQS: %s\n" msg-body)
@@ -20,6 +31,7 @@
       :invite (mailer/send-invite msg-body)
       :share-entry (mailer/send-entry msg-body)
       :digest (mailer/send-digest msg-body)
+      :sns (mailer/handle-data-change msg-body)
       (timbre/error "Unrecognized message type" msg-type)))
   (sqs/ack done-channel msg))
 

--- a/src/oc/email/content.clj
+++ b/src/oc/email/content.clj
@@ -3,6 +3,7 @@
             [clojure.walk :refer (keywordize-keys)]
             [clj-time.format :as format]
             [hiccup.core :as h]
+            [taoensso.timbre :as timbre]
             [oc.lib.text :as text]
             [oc.email.config :as config]))
 
@@ -178,6 +179,19 @@
                                   [:td
                                     [:a {:href url} cta]]]]]]]]]]]
                 [:th {:class "expander"}]]]]]]]])
+
+(defn- board-notification-content [data]
+  (let [org-name (:org data)
+        user (:user data)
+        board-url (:board-url data)
+        first-name (if (s/blank? (:first-name user)) "there" (:first-name user))]
+    [:td
+      (spacer 15)
+      (paragraph (str "Hi " first-name "! " (:text data)))
+      (spacer 15)
+      (cta-button "Check it out." board-url)
+      (spacer 30)
+      (paragraph tagline)]))
 
 (defn- invite-content [invite]
   (let [logo-url (:logo-url invite)
@@ -393,6 +407,7 @@
                       :reset (token-content type data)
                       :verify (token-content type data)
                       :invite (invite-content data)
+                      :board-notification (board-notification-content data)
                       :digest (digest-content data))]]])]]]]))
 
 (defn- head [data]
@@ -462,6 +477,9 @@
 
 (defn digest-html [digest]
   (html digest :digest))
+
+(defn board-notification-html [message]
+  (html message :board-notification))
 
 (comment
   

--- a/src/oc/email/content.clj
+++ b/src/oc/email/content.clj
@@ -3,7 +3,6 @@
             [clojure.walk :refer (keywordize-keys)]
             [clj-time.format :as format]
             [hiccup.core :as h]
-            [taoensso.timbre :as timbre]
             [oc.lib.text :as text]
             [oc.email.config :as config]))
 

--- a/src/oc/email/mailer.clj
+++ b/src/oc/email/mailer.clj
@@ -5,6 +5,7 @@
             [clojure.walk :refer (keywordize-keys)]
             [taoensso.timbre :as timbre]
             [amazonica.aws.simpleemail :as ses]
+            [cheshire.core :as json]
             [oc.email.config :as c]
             [oc.email.content :as content]))
 
@@ -143,6 +144,56 @@
         ; remove the tmp files
         (io/delete-file html-file true)
         (io/delete-file inline-file true)))))
+
+(defn- send-private-board-notification
+  "Creates an html email and sends it to the recipient."
+  [msg]
+  (let [uuid-fragment (subs (str (java.util.UUID/randomUUID)) 0 4)
+        html-file (str uuid-fragment ".html")
+        inline-file (str uuid-fragment ".inline.html")
+        org-name (:name (:org msg))]
+    (try
+      (spit html-file (content/board-notification-html msg)) ; create the email in a tmp file
+      (inline-css html-file inline-file) ; inline the CSS
+       ;; Email it to the recipient
+      (email {:to (:email (:user msg))
+              :source default-source
+              :from default-from
+              :reply-to default-reply-to
+              :subject (str c/email-digest-prefix org-name)}
+             {:html (slurp inline-file)})
+      (finally
+       ;; remove the tmp files
+       (io/delete-file html-file true)
+       (io/delete-file inline-file true)))))
+
+(defn handle-data-change
+  "
+  Test to see if message is a board change and that it has notifications.
+  If so, check if they are slack users and if not send an email.
+  "
+  [message]
+  (let [msg-parsed (json/parse-string (:Message message) true)]
+    (when (and
+           (or
+            (= (:notification-type msg-parsed) "update")
+            (= (:notification-type msg-parsed) "add"))
+           (= (:resource-type msg-parsed) "board"))
+      (let [notifications (:notifications (:content msg-parsed))
+            board (:new (:content msg-parsed))
+            user (:user msg-parsed)]
+        (doseq [notify notifications]
+          (let [slack-info (first (vals (:slack-users notify)))]
+            (when-not slack-info
+              (let [board-url (s/join "/" [c/web-url
+                                           (:slug (:org msg-parsed))
+                                           (:slug board)])
+                    message "You have been invited to a private board. "]
+                (send-private-board-notification {
+                                                  :user notify
+                                                  :org (:org msg-parsed)
+                                                  :board-url board-url
+                                                  :text message})))))))))
 
 (comment
 

--- a/src/oc/email/mailer.clj
+++ b/src/oc/email/mailer.clj
@@ -174,17 +174,18 @@
   "
   [message]
   (let [msg-parsed (json/parse-string (:Message message) true)]
-    (when (and
-           (or
-            (= (:notification-type msg-parsed) "update")
-            (= (:notification-type msg-parsed) "add"))
-           (= (:resource-type msg-parsed) "board"))
-      (let [notifications (:notifications (:content msg-parsed))
-            board (:new (:content msg-parsed))
+    (when (and ; update or add on a board
+            (or
+              (= (:notification-type msg-parsed) "update")
+              (= (:notification-type msg-parsed) "add"))
+            (= (:resource-type msg-parsed) "board"))
+      (let [notifications (-> msg-parsed :content :notifications)
+            board (-> msg-parsed :content :new)
             user (:user msg-parsed)]
+
         (doseq [notify notifications]
           (let [slack-info (first (vals (:slack-users notify)))]
-            (when-not slack-info
+            (when-not slack-info ; Slack users get notified elsewhere via Slack
               (let [board-url (s/join "/" [c/web-url
                                            (:slug (:org msg-parsed))
                                            (:slug board)])


### PR DESCRIPTION

You will need to subscribe the email sqs to the storage SNS arn see the bot PR for details.
https://github.com/open-company/open-company-bot/pull/21/files


To test: 

- [x] Create a private board and add an email user without slack credentials.
- [x] Does this user receive an email saying they were invited to a private board?
- [x] merge