### PR TITLE
Fix mobile padding

### DIFF
--- a/resources/email-template.html
+++ b/resources/email-template.html
@@ -19,7 +19,8 @@
               <!-- Content -->
               <table class="row email-content" valign="middle" align="center">
                 <tr>
-                  <td class="small-12 large-12 columns" valign="middle" align="center">
+                  <td class="small-1 hide-for-large columns" valign="middle" align="left">
+                  <td class="small-10 large-12 columns" valign="middle" align="center">
                     <!-- Real content -->
                     <!-- Spacer 15 -->
                     <table class="row">
@@ -60,13 +61,15 @@
                     <!-- Spacer 15 end -->
                     <!-- Real content end -->
                   </td>
+                  <td class="small-1 hide-for-large columns" valign="middle" align="right">
                 </tr>
               </table>
               <!-- Content end -->
               <!-- Footer -->
               <table class="row footer-table" valign="middle" align="center">
                 <tr>
-                  <td class="small-12 large-12 columns" valign="middle" align="center">
+                  <td class="small-1 hide-for-large columns" valign="middle" align="left">
+                  <td class="small-10 large-12 columns" valign="middle" align="center">
                      <!-- Spacer 24 -->
                     <table class="row footer-table">
                       <tr>
@@ -129,6 +132,7 @@
                     </table>
                     <!-- Spacer 40 end -->
                   </td>
+                  <td class="small-1 hide-for-large columns" valign="middle" align="right">
                 </tr>
               </table>
               <!-- Footer end -->

--- a/src/oc/email/content.clj
+++ b/src/oc/email/content.clj
@@ -221,7 +221,8 @@
            :valign "middle"
            :align "center"}
     [:tr
-      [:td {:class "small-12 large-12 columns" :valign "middle" :align "center"}
+      [:td {:class "small-1 hide-for-large columns" :valign "middle" :align "left"}]
+      [:td {:class "small-10 large-12 columns" :valign "middle" :align "center"}
         (vspacer 24 "footer-table" "footer-table")
         (vspacer 24 "footer-table footer-top-border" "footer-table")
         [:table {:class "row footer-table"}
@@ -238,7 +239,8 @@
                        :width "13"
                        :height "24"
                        :alt "Carrot"}]]]]]
-        (vspacer 40 "footer-table" "footer-table")]]])
+        (vspacer 40 "footer-table" "footer-table")]
+      [:td {:class "small-1 hide-for-large columns" :valign "middle" :align "right"}]]])
 
 ;; ----- Posts common ----
 
@@ -287,7 +289,7 @@
         subtitle (if (s/blank? first-name)
                     digest-message-no-name
                     (format digest-message first-name))]
-    [:td {:class "small-12 large-12 columns" :valign "middle" :align "center"}
+    [:td {:class "small-10 large-12 columns" :valign "middle" :align "center"}
       (spacer 40)
       (when logo? (org-logo {:org-name (:org-name digest)
                              :org-logo-url logo-url
@@ -335,7 +337,7 @@
         note (:note notice)
         note? (not (s/blank? note))
         show-note? (and from-avatar? note?)]
-    [:td {:class "small-12 large-12 columns" :valign "middle" :align "center"}
+    [:td {:class "small-10 large-12 columns" :valign "middle" :align "center"}
       (spacer 40)
       (when logo? (org-logo {:org-name org-name
                              :org-logo-url logo-url
@@ -416,7 +418,7 @@
         secure-uuid (:secure-uuid entry)
         origin-url config/web-url
         entry-url (s/join "/" [origin-url org-slug "post" secure-uuid])]
-    [:td {:class "small-12 large-12 columns" :valign "middle" :align "center"}
+    [:td {:class "small-10 large-12 columns" :valign "middle" :align "center"}
       (spacer 40)
       (when logo? (org-logo entry))
       (when logo? (spacer 32))
@@ -479,13 +481,19 @@
                        :valign "middle"
                        :align "center"}
                 [:tr
+                  [:td {:class "small-1 hide-for-large columns"
+                        :valign "middle"
+                        :align "left"}]
                   (case type
-                    :reset (token-content "small-12 large-12 columns" type data)
-                    :verify (token-content "small-12 large-12 columns" type data)
-                    :invite (invite-content "small-12 large-12 columns" data)
+                    :reset (token-content "small-10 large-12 columns" type data)
+                    :verify (token-content "small-10 large-12 columns" type data)
+                    :invite (invite-content "small-10 large-12 columns" data)
                     :board-notification (board-notification-content data)
                     :share-link (share-content data)
-                    :digest (digest-content data))]]
+                    :digest (digest-content data))
+                  [:td {:class "small-1 hide-for-large columns"
+                        :valign "middle"
+                        :align "right"}]]]
               (email-footer)]]]]]))
 
 (defn- head [data]


### PR DESCRIPTION
Bug: Email templates on mobile lost padding https://trello.com/c/4X1Ulxj1

From: https://paper.dropbox.com/doc/Misc-UX--AMsFP80dtpKK~ftF~v8yet80Ag-zmqEXqPjOZGPJJSxUfPxC

To test:
- send you some test emails
- [x] check them on desktop, they look right? Good
- [x] on desktop the content space is 600px? Good
- [x] do you see padding on the left and right borders on mobile? Good