### PR TITLE
More email digest tweaks

### DIFF
--- a/resources/css/oc.css
+++ b/resources/css/oc.css
@@ -504,6 +504,10 @@ img.logo {
   object-fit: contain;
 }
 
+.hidden {
+  display: none;
+}
+
 /*
   Gmail doesn't linke multiple media queries, if you need to use
   @media only screen and (max-width:596px)

--- a/src/oc/email/content.clj
+++ b/src/oc/email/content.clj
@@ -380,7 +380,7 @@
       "\"publisher\": {"
         "\"@type\": \"Organization\","
         "\"name\": \"Carrot\","
-        "\"url\": \"https://carrot.io/\","
+        "\"url\": \"" config/web-url "\","
       "}"
     "}"])
 

--- a/src/oc/email/content.clj
+++ b/src/oc/email/content.clj
@@ -368,21 +368,21 @@
 
 (defn- go-to-posts-script [data]
   [:script {:type "application/ld+json"}
-    "{"
-      "\"@context\": \"http://schema.org\","
-      "\"@type\": \"EmailMessage\","
-      "\"description\": \"" (digest-title (:org-name data) (weekly-digest? data)) "\","
-      "\"potentialAction\": {"
-        "\"@type\": \"ViewAction\","
-        "\"target\": \"" (get-digest-url data) "\","
-        "\"name\": \"Go to posts\""
-      "},"
-      "\"publisher\": {"
-        "\"@type\": \"Organization\","
-        "\"name\": \"Carrot\","
-        "\"url\": \"" config/web-url "\","
-      "}"
-    "}"])
+"{
+  \"@context\": \"http://schema.org\",
+  \"@type\": \"EmailMessage\",
+  \"description\": \"" (digest-title (:org-name data) (weekly-digest? data)) "\",
+  \"potentialAction\": {
+  \"@type\": \"ViewAction\",
+    \"target\": \"" (get-digest-url data) "\",
+    \"name\": \"Go to posts\"
+  },
+  \"publisher\": {
+    \"@type\": \"Organization\",
+    \"name\": \"Carrot\",
+    \"url\": \"" config/web-url "\",
+  }
+}"])
 
 (defn- digest-content [digest]
   (let [logo-url (:logo-url digest)

--- a/src/oc/email/content.clj
+++ b/src/oc/email/content.clj
@@ -361,7 +361,7 @@
   (let [org-name (:org-name digest-data)
         weekly? (weekly-digest? digest-data)]
     [:span.hidden
-      (str (digest-title org-name weekly?) ". See the latest updates from your team." (s/join (repeat 65 "🥕")))]))
+      (str (digest-title org-name weekly?) ". See the latest updates from your team." (s/join (repeat 100 "&nbsp;&zwnj;")))]))
 
 (defn- get-digest-url [digest-data]
   (s/join "/" [config/web-url (:org-slug digest-data) "all-posts"]))
@@ -375,13 +375,8 @@
   \"description\": \"" (digest-title (:org-name data) (weekly-digest? data)) "\",
   \"potentialAction\": {
     \"@type\": \"ViewAction\",
-    \"url\": \"" (get-digest-url data) "\",
+    \"target\": \"" (get-digest-url data) "\",
     \"name\": \"Go to posts\"
-  },
-  \"publisher\": {
-    \"@type\": \"Organization\",
-    \"name\": \"Carrot\",
-    \"url\": \"" config/web-url "\"
   }
 }
 "])
@@ -638,6 +633,8 @@
 (defn- body [data]
   (let [type (:type data)]
     [:body
+      (when (= (:type data) :digest)
+        (go-to-posts-script data))
       (when (= type :digest)
         (hidden-digest-headline data))
       [:table {:class "body"
@@ -668,9 +665,7 @@
       [:meta {:name "viewport", :content "width=device-width"}]
       [:link {:rel "stylesheet", :href "resources/css/foundation.css"}]
       [:link {:rel "stylesheet", :href (str "resources/css/oc.css")}]
-      [:title]
-      (when (= (:type data) :digest)
-        (go-to-posts-script data))]
+      [:title]]
     (body data)])
 
 (defn- html [data type]

--- a/src/oc/email/content.clj
+++ b/src/oc/email/content.clj
@@ -357,11 +357,11 @@
       (format digest-title-daily "at" org-name)
       (format digest-title-daily "in" "Carrot"))))
 
-(defn- hidden-digest-headline [digest-data]
+(defn- digest-preheader [digest-data]
   (let [org-name (:org-name digest-data)
         weekly? (weekly-digest? digest-data)]
     [:span.hidden
-      (str (digest-title org-name weekly?) ". See the latest updates from your team." (s/join (repeat 100 "&nbsp;&zwnj;")))]))
+      (str "See the latest updates from your team." (s/join (repeat 120 "&nbsp;&zwnj;")))]))
 
 (defn- get-digest-url [digest-data]
   (s/join "/" [config/web-url (:org-slug digest-data) "all-posts"]))
@@ -636,7 +636,7 @@
       (when (= (:type data) :digest)
         (go-to-posts-script data))
       (when (= type :digest)
-        (hidden-digest-headline data))
+        (digest-preheader data))
       [:table {:class "body"
                :with "100%"}
         [:tr

--- a/src/oc/email/content.clj
+++ b/src/oc/email/content.clj
@@ -368,21 +368,23 @@
 
 (defn- go-to-posts-script [data]
   [:script {:type "application/ld+json"}
-"{
+"
+{
   \"@context\": \"http://schema.org\",
   \"@type\": \"EmailMessage\",
   \"description\": \"" (digest-title (:org-name data) (weekly-digest? data)) "\",
   \"potentialAction\": {
-  \"@type\": \"ViewAction\",
-    \"target\": \"" (get-digest-url data) "\",
+    \"@type\": \"ViewAction\",
+    \"url\": \"" (get-digest-url data) "\",
     \"name\": \"Go to posts\"
   },
   \"publisher\": {
     \"@type\": \"Organization\",
     \"name\": \"Carrot\",
-    \"url\": \"" config/web-url "\",
+    \"url\": \"" config/web-url "\"
   }
-}"])
+}
+"])
 
 (defn- digest-content [digest]
   (let [logo-url (:logo-url digest)

--- a/src/oc/email/content.clj
+++ b/src/oc/email/content.clj
@@ -348,6 +348,42 @@
   (or (= "weekly" (:digest-frequency digest-data))
       (= :weekly (:digest-frequency digest-data))))
 
+(defn digest-title [org-name weekly?]
+  (if weekly?
+    (if org-name
+      (format digest-title-weekly "at" org-name)
+      (format digest-title-weekly "in" "Carrot"))
+    (if org-name
+      (format digest-title-daily "at" org-name)
+      (format digest-title-daily "in" "Carrot"))))
+
+(defn- hidden-digest-headline [digest-data]
+  (let [org-name (:org-name digest-data)
+        weekly? (weekly-digest? digest-data)]
+    [:span.hidden
+      (str (digest-title org-name weekly?) ". See the latest updates from your team." (s/join (repeat 65 "🥕")))]))
+
+(defn- get-digest-url [digest-data]
+  (s/join "/" [config/web-url (:org-slug digest-data) "all-posts"]))
+
+(defn- go-to-posts-script [data]
+  [:script {:type "application/ld+json"}
+    "{"
+      "\"@context\": \"http://schema.org\","
+      "\"@type\": \"EmailMessage\","
+      "\"description\": \"" (digest-title (:org-name data) (weekly-digest? data)) "\","
+      "\"potentialAction\": {"
+        "\"@type\": \"ViewAction\","
+        "\"target\": \"" (get-digest-url data) "\","
+        "\"name\": \"Go to posts\""
+      "},"
+      "\"publisher\": {"
+        "\"@type\": \"Organization\","
+        "\"name\": \"Carrot\","
+        "\"url\": \"https://carrot.io/\","
+      "}"
+    "}"])
+
 (defn- digest-content [digest]
   (let [logo-url (:logo-url digest)
         logo? (not (s/blank? logo-url))
@@ -355,15 +391,9 @@
         org-name (:org-name digest)
         boards (map posts-with-board-name (:boards digest))
         posts (mapcat :posts boards)
-        digest-url (s/join "/" [config/web-url (:org-slug digest) "all-posts"])
+        digest-url (get-digest-url digest)
         first-name (:first-name digest)
-        title (if org-name
-                (if weekly?
-                  (format digest-title-daily "at" org-name)
-                  (format digest-title-weekly "at" org-name))
-                (if weekly?
-                  (format digest-title-daily "in" "Carrot")
-                  (format digest-title-weekly "in" "Carrot")))]
+        digest-headline (digest-title org-name weekly?)]
     [:td {:class "small-12 large-12 columns main-wrapper" :valign "middle" :align "center"}
       [:center
         (when logo? (org-logo {:org-name (:org-name digest)
@@ -372,7 +402,7 @@
                                :org-logo-height (:logo-height digest)
                                :align "center"}))
         (when logo? (spacer 32))
-        (h1 title "center-align")
+        (h1 digest-headline "center-align")
         (spacer 16)
         [:table {:class "row"}
           [:tr
@@ -606,6 +636,8 @@
 (defn- body [data]
   (let [type (:type data)]
     [:body
+      (when (= type :digest)
+        (hidden-digest-headline data))
       [:table {:class "body"
                :with "100%"}
         [:tr
@@ -634,7 +666,9 @@
       [:meta {:name "viewport", :content "width=device-width"}]
       [:link {:rel "stylesheet", :href "resources/css/foundation.css"}]
       [:link {:rel "stylesheet", :href (str "resources/css/oc.css")}]
-      [:title]]
+      [:title]
+      (when (= (:type data) :digest)
+        (go-to-posts-script data))]
     (body data)])
 
 (defn- html [data type]

--- a/src/oc/email/mailer.clj
+++ b/src/oc/email/mailer.clj
@@ -130,7 +130,13 @@
         org-name (:org-name msg)
         daily? (= (keyword (:digest-frequency msg)) :daily)
         frequency (if daily? "Daily" "Weekly")
-        digest-email-subject (if daily? "Your daily brief" "Your weekly brief")]
+        digest-email-subject (if daily?
+                              (if org-name
+                                (str "Yesterday at " org-name)
+                                (str "Yesterday in Carrot"))
+                              (if org-name
+                                (str "Last week at " org-name)
+                                (str "Last week in Carrot")))]
     (try
       (spit html-file (content/digest-html msg)) ; create the email in a tmp file
       (inline-css html-file inline-file) ; inline the CSS

--- a/src/oc/email/mailer.clj
+++ b/src/oc/email/mailer.clj
@@ -130,13 +130,7 @@
         org-name (:org-name msg)
         daily? (= (keyword (:digest-frequency msg)) :daily)
         frequency (if daily? "Daily" "Weekly")
-        digest-email-subject (if daily?
-                              (if org-name
-                                (str "Yesterday at " org-name)
-                                (str "Yesterday in Carrot"))
-                              (if org-name
-                                (str "Last week at " org-name)
-                                (str "Last week in Carrot")))]
+        digest-email-subject (content/digest-title org-name (not daily?))]
     (try
       (spit html-file (content/digest-html msg)) ; create the email in a tmp file
       (inline-css html-file inline-file) ; inline the CSS


### PR DESCRIPTION
Card: https://trello.com/c/aWCcYRDZ

To test:
- send your self a daily digest email
- [x] subject is ok? Same as email headline? Good
- [x] do you see only "Yesterday at org. See the latest updates from your team." as preheader (when the email is still closed, increase the width of the window to see more text besides the subject)? Good
- send your self a weekly digest email
- [x] subject is ok? Same as email headline? Good
- [x] do you see only "Last week at org. See the latest updates from your team." as preheader? Good

NB: this also introduces the json+ld data to add the Go to posts button on Gmail but that require their review still. Ping me once this is reviewed, i need to send them an email at schema.whitelisting+sample@gmail.com from our production server so they can review the request (also need to send this form compiled https://docs.google.com/forms/d/e/1FAIpQLSfT5F1VJXtBjGw2mLxY2aX557ctPTsCrJpURiKJjYeVrugHBQ/viewform?pli=1)