### PR TITLE
Handle the nil title case

### DIFF
--- a/src/oc/email/mailer.clj
+++ b/src/oc/email/mailer.clj
@@ -197,7 +197,7 @@
         title (if comment?
                 (:headline post-data)
                 (:entry-title notification))
-        parsed-title (.text (soup/parse title))
+        parsed-title (.text (soup/parse (or title "")))
         updated-post-data (assoc post-data :parsed-headline parsed-title)
         msg-title (assoc-in msg [:notification :entry-data] updated-post-data)
         pre-subject (if mention?


### PR DESCRIPTION
https://sentry.io/opencompany/oc-beta-email/issues/803947687/?referrer=slack

To test send a notification via email with a post that doesn't have a title.