### PR TITLE
Always use post data to get the title/headline.

### DIFF
--- a/src/oc/email/mailer.clj
+++ b/src/oc/email/mailer.clj
@@ -194,9 +194,7 @@
         mention? (:mention notification)
         comment? (:interaction-id notification)
         post-data (post-data-from-msg msg)
-        title (if comment?
-                (:headline post-data)
-                (:entry-title notification))
+        title (:headline post-data)
         parsed-title (.text (soup/parse title))
         updated-post-data (assoc post-data :parsed-headline parsed-title)
         msg-title (assoc-in msg [:notification :entry-data] updated-post-data)


### PR DESCRIPTION
Since we always query for the post data , use the post data to get the headline/title.

To test:

- create a user with email as the notification setting.
- mention that user in a post
- [x] is an email sent with the post data?

- mention that user in a comment
- [x] is an email sent with the post data?