### PR TITLE
Transactional emails preheader

### DIFF
--- a/src/oc/email/mailer.clj
+++ b/src/oc/email/mailer.clj
@@ -88,7 +88,7 @@
                   (assoc :source default-source)
                   (assoc :from default-from)
                   (assoc :reply-to default-reply-to)
-                  (assoc :subject (str "🔔 " (content/reminder-notification-headline reminder-data))))]
+                  (assoc :subject (str "🔔 " (content/reminder-notification-headline message))))]
     (try
       (spit html-file (content/reminder-notification-html reminder)) ; create the email in a tmp file
       (inline-css html-file inline-file) ; inline the CSS


### PR DESCRIPTION
Card: https://trello.com/c/t2pNeoLA

To test:
- send yourself a verification email (`:verify`)
- [x] do you see a clean preheader? Good
- [x] do you NOT see the preheader in the email body? Good
- send yourself an invitation email (`:invite`)
- [x] do you see a clean preheader? Good
- [x] do you NOT see the preheader in the email body? Good
- send yourself a reset password email (`:reset`)
- [x] do you see a clean preheader? Good
- [x] do you NOT see the preheader in the email body? Good
- send yourself a private board invitation email (`:board-notification`)
- [x] do you see a clean preheader? Good
- [x] do you NOT see the preheader in the email body? Good
- send yourself a share entry email (`:share-link`)
- [x] do you see a clean preheader? Good
- [x] do you NOT see the preheader in the email body? Good
- send yourself a digest email (`:digest`)
- [x] do you see a clean preheader? Good
- [x] do you NOT see the preheader in the email body? Good
- send yourself a new comment notification email (`:notify`)
- [x] do you see a clean preheader? Good
- [x] do you NOT see the preheader in the email body? Good
- send yourself a new mention in post notification email (`:notify`)
- [x] do you see a clean preheader? Good
- [x] do you NOT see the preheader in the email body? Good
- send yourself a new mention in comment notification email (`:notify`)
- [x] do you see a clean preheader? Good
- [x] do you NOT see the preheader in the email body? Good